### PR TITLE
Use Copybara image from banksalad ECR 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ inputs:
   copybara_image:
     description: "Copybara Docker image to run."
     required: false
-    default: "olivr/copybara"
+    default: "649962636948.dkr.ecr.ap-northeast-2.amazonaws.com/copybara"
 
   copybara_image_tag:
     description: "Copybara Docker image tag to use."


### PR DESCRIPTION
# Pull request

Upstream에서 사용하던 olivr/copybara 이미지가 docker에서 가져오다보니 빈번하게 사용할 경우 권한 문제가 발생하기 때문에 ECR에 image를 구성해두고 action에서 사용하는 기본 이미지를 ECR에 있는 copybara로 변경합니다.

## 관련 PR
- https://github.com/banksalad/iac-cloud/pull/808 

